### PR TITLE
Add ability to add a track of a specified URI to the user queue

### DIFF
--- a/oauth2.py
+++ b/oauth2.py
@@ -83,7 +83,7 @@ class SpotifyAPIOAuth2(object):
         if auth_type == "client_credentials":
             r = requests.post(self.token_url, data=self.get_token_data("client_credentials"), headers=self.get_token_headers())
         elif auth_type == "authorization_code":
-            auth_code = self.get_auth_code()
+            self.store_auth_code()
 
             r = requests.post(self.token_url, data=self.get_token_data("authorization_code"), headers=self.get_token_headers())
         else:
@@ -139,9 +139,9 @@ class SpotifyAPIOAuth2(object):
             "state": 123
         }
 
-    def get_auth_code(self):
+    def store_auth_code(self):
         """
-        Obtains and returns a user authorization code (with the consent of the user).
+        Obtains (with the consent of the user) a user authorization code and stores it as an instance variable.
 
         :return: The authorization code obtained from the user.
         """
@@ -151,7 +151,7 @@ class SpotifyAPIOAuth2(object):
         webbrowser.open(auth_code_url)
         uri = input("Please enter the URL you were redirected to: ")
 
-        return self.get_code_from_uri(uri)
+        self.auth_code = self.get_code_from_uri(uri)
 
     def get_code_from_uri(self, uri):
         """

--- a/oauth2.py
+++ b/oauth2.py
@@ -24,7 +24,6 @@ class SpotifyAPIOAuth2(object):
 
         :param client_id: The id associated with the registered Spotify application.
         :param client_secret: The secret key associated with the registered Spotify application.
-        :param redirect_uri: The URI which the Spotify client authentication service should redirect the user to after authenticating.
         """
         super().__init__(*args, **kwargs)
         self.client_id = client_id
@@ -62,11 +61,11 @@ class SpotifyAPIOAuth2(object):
         :return: The data to be used to make a request to retreive the token associated with this application.
         """
         data = {
-            "grant_type": "client_credentials"
+            "grant_type": auth_type
         }
 
         if auth_type == "authorization_code":
-            data["code"] = self.auth_code,
+            data["code"] = self.auth_code
             data["redirect_uri"] = self.redirect_uri
 
         return data
@@ -110,9 +109,9 @@ class SpotifyAPIOAuth2(object):
         :param auth_type: A string representing which type of authentication should be performed.
         :return: A valid authentication token that is presently stored within the object.
         """
-        token = self.access_token
-        
         auth_done = self.perform_auth(auth_type)
+
+        token = self.access_token
         
         if not auth_done:
             raise Exception("Authentication failed")

--- a/oauth2.py
+++ b/oauth2.py
@@ -1,16 +1,22 @@
 import base64
 import datetime
 from urllib.parse import urlencode
+import webbrowser
+import urllib.parse as urllibparse
+from urllib.parse import parse_qs
 
 import requests
 
 class SpotifyAPIOAuth2(object):
     access_token = None
     access_token_expires = None
+    auth_code = None
+    redirect_uri = "http://jasondamico.me"
     access_token_did_expire = True
     client_id = None
     client_secret = None
     token_url = "https://accounts.spotify.com/api/token"
+    auth_code_url = "https://accounts.spotify.com/authorize"
     
     def __init__(self, client_id, client_secret, *args, **kwargs):
         """
@@ -18,6 +24,7 @@ class SpotifyAPIOAuth2(object):
 
         :param client_id: The id associated with the registered Spotify application.
         :param client_secret: The secret key associated with the registered Spotify application.
+        :param redirect_uri: The URI which the Spotify client authentication service should redirect the user to after authenticating.
         """
         super().__init__(*args, **kwargs)
         self.client_id = client_id
@@ -48,26 +55,37 @@ class SpotifyAPIOAuth2(object):
             "Authorization": f"Basic {client_creds_b64}"
         }
     
-    def get_token_data(self, auth_code=False):
+    def get_token_data(self, auth_type):
         """
         Returns a dictionary containing the token data to be used in the post request to receive the client token URL.
 
         :return: The data to be used to make a request to retreive the token associated with this application.
         """
-        return {
+        data = {
             "grant_type": "client_credentials"
         }
+
+        if auth_type == "authorization_code":
+            data["code"] = self.auth_code,
+            data["redirect_uri"] = self.redirect_uri
+
+        return data
         
     def perform_auth(self, auth_type):     
         """ 
         Performs the authentication of the the client application based on the stored client id and client key. Returns TRUE if the authentication was successful, throws an exception otherwise.
 
-        :param auth_type: A string representing which type of authentication should be performed. One possible options is available at this time:
+        :param auth_type: A string representing which type of authentication should be performed. Two possible options are available at this time:
             - `"client_credentials"`
+            - `"authorization_code"`
         :return: TRUE if the authentication was successful.
         """   
         if auth_type == "client_credentials":
-            r = requests.post(self.token_url, data=self.get_token_data(), headers=self.get_token_headers())
+            r = requests.post(self.token_url, data=self.get_token_data("client_credentials"), headers=self.get_token_headers())
+        elif auth_type == "authorization_code":
+            auth_code = self.get_auth_code()
+
+            r = requests.post(self.token_url, data=self.get_token_data("authorization_code"), headers=self.get_token_headers())
         else:
             raise Exception("Invalid authorization flow entered.")
 
@@ -106,3 +124,41 @@ class SpotifyAPIOAuth2(object):
             return self.get_access_token(auth_type)
         
         return token
+
+    def get_auth_code_params(self):
+        """
+        Returns a dictionary containing the parameters to be used in obtaining the authorization code.
+
+        :return: The parameters to be passed to the authorization code URL to obtain a user authorization code.
+        """
+        return {
+            "client_id": self.client_id,
+            "response_type": "code",
+            "redirect_uri": self.redirect_uri,
+            "scope": "user-modify-playback-state",
+            "state": 123
+        }
+
+    def get_auth_code(self):
+        """
+        Obtains and returns a user authorization code (with the consent of the user).
+
+        :return: The authorization code obtained from the user.
+        """
+        url_params = urllibparse.urlencode(self.get_auth_code_params())
+        auth_code_url = "%s?%s" % (self.auth_code_url, url_params)
+
+        webbrowser.open(auth_code_url)
+        uri = input("Please enter the URL you were redirected to: ")
+
+        return self.get_code_from_uri(uri)
+
+    def get_code_from_uri(self, uri):
+        """
+        Retrieves the code from the passed URI and returns the value.
+
+        :return: The code stored within the passed URI.
+        """
+        parsed = urllibparse.urlparse(uri)
+
+        return parse_qs(parsed.query)["code"][0]

--- a/spotify_client.py
+++ b/spotify_client.py
@@ -122,3 +122,40 @@ class SpotifyAPI(oauth2.SpotifyAPIOAuth2):
         query_params = urlencode(query_params)
         
         return self.base_search(query_params)
+
+    def get_queue_headers(self):
+        """
+        Returns a dictionary holding the header values to be used in a query to add a track to the user's queue.
+
+        :return: The headers arguments to be used when making a request to add to a user's queue.
+        """
+        token = self.get_access_token("authorization_code")
+
+        headers = {
+            "Authorization": f"Bearer {token}"
+        }
+
+        return headers
+
+    def get_queue_params(self, uri):
+        """
+        Returns a dictionary holding the paramater values to be used in a query to add a track with the passed URI to the user's queue.
+
+        :param uri: The URI of a track to be added to the user's queue.
+        :return: The params arguments to be used when making a request to add to a user's queue.
+        """
+        return {
+            "uri": uri
+        }
+
+    def add_to_queue(self, uri):
+        """
+        Adds the track held at the passed URI to the user queue.
+
+        :param uri: The URI of a track to be added to the user's queue.
+        """
+        endpoint = "https://api.spotify.com/v1/me/player/queue"
+        params = self.get_queue_params(uri)
+        headers = self.get_queue_headers()
+
+        r = requests.post(endpoint, params=params, headers=headers)


### PR DESCRIPTION
Uses the [Authorization Code Flow](https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow) to authorize client and gain access to the user playback state, allowing for a track to be added to the queue based on a passed URI.

Closes #1, closes #2.