### PR TITLE
Added ability to add an entire album to the queue

### DIFF
--- a/src/queue_bot.py
+++ b/src/queue_bot.py
@@ -23,7 +23,7 @@ class QueueBot():
         self.active = True
 
         while self.active:
-            raw_query = input("Enter the name of the track you would like to add to your queue: ")
+            raw_query = input("Enter the name of the item you would like to add to your queue: ")
             query = self.__process_queue_query(raw_query)
             
             if self.active:
@@ -44,7 +44,7 @@ class QueueBot():
 
                         self.spotify.add_album_to_queue(album_id)
                 except IndexError:
-                    print("No tracks returned for \'%s\'." % raw_query)
+                    print("No results returned for \'%s\'." % raw_query)
 
     def __process_queue_query(self, query):
         """

--- a/src/queue_bot.py
+++ b/src/queue_bot.py
@@ -44,5 +44,13 @@ class QueueBot():
         """
         if query == "-quit":
             self.active = False
+        elif self.__has_album_flag(query):
+            return query.replace("-album", "")
         else:
             return query
+
+    def __has_album_flag(self, query):
+        """
+        Returns a boolean corresponding to whether or not the passed query has an album flag (-album), corresponding to a wish for an entire album to be queued.
+        """
+        return "-album" in query

--- a/src/queue_bot.py
+++ b/src/queue_bot.py
@@ -27,11 +27,22 @@ class QueueBot():
             query = self.__process_queue_query(raw_query)
             
             if self.active:
-                tracks = self.spotify.search(query, search_type="track")
-                try:
-                    track_uri = self.spotify.get_first_track_uri(tracks)
+                if self.__has_album_flag(raw_query):
+                    search_type = "album"
+                else:
+                    search_type = "track"
 
-                    self.spotify.add_to_queue(track_uri)
+                results = self.spotify.search(query, search_type=search_type)
+
+                try:
+                    if search_type == "track":
+                        track_uri = self.spotify.get_first_track_uri(results)
+
+                        self.spotify.add_to_queue(track_uri)
+                    else:
+                        album_id = self.spotify.get_first_album_id(results)
+
+                        self.spotify.add_album_to_queue(album_id)
                 except IndexError:
                     print("No tracks returned for \'%s\'." % raw_query)
 

--- a/src/spotify_client.py
+++ b/src/spotify_client.py
@@ -180,3 +180,25 @@ class SpotifyAPI(oauth2.SpotifyAPIOAuth2):
         :return: The URI of the first track held in the passed JSON object.
         """
         return track_search_json["tracks"]["items"][0]["uri"]
+
+    def get_first_album_id(self, album_search_json):
+        """
+        Returns the ID of the of the first album stored in the passed JSON object returned from an album search query.
+
+        :param album_search_json: The JSON object returned from an album search.
+        :return: The ID of the first album object held in the passed JSON object.
+        """
+        return album_search_json["albums"]["items"][0]["id"]
+
+    def add_album_to_queue(self, album_id):
+        """
+        Adds the album held at the passed ID to the user queue.
+
+        :param album_id: The ID of the album to be added to the user queue.
+        """
+        album = self.get_album(album_id)
+        tracks = album["tracks"]["items"]
+
+        for track in tracks:
+            uri = track["uri"]
+            self.add_to_queue(uri)


### PR DESCRIPTION
Instead of adding a singular track, the first album found in the user's inputted query will be added to the user's queue. Accomplished by using the `-album` flag within the search query.